### PR TITLE
Add service CIDR to BGPConfiguration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -312,4 +312,6 @@
         name: default
       spec:
         nodeToNodeMeshEnabled: false
+        serviceClusterIPs:
+          - cidr: "{{ kubernetes_service_cidr }}"
         asNumber: "{{ kubernetes_autonomous_system_number }}"


### PR DESCRIPTION
This is now the preferred way to advertise service IPs instead of setting the env. variable (see https://github.com/vsk8s/ansible-calico-node/pull/1)